### PR TITLE
Make venv installation Guide for windows OS

### DIFF
--- a/notebooks/ch-states/atoms-computation.ipynb
+++ b/notebooks/ch-states/atoms-computation.ipynb
@@ -258,7 +258,7 @@
    "source": [
     "The reason for running many times and showing the result as a histogram is because quantum computers may have some randomness in their results. In this case, since we aren’t doing anything quantum, we get just the ```00000000``` result with certainty.\n",
     "\n",
-    "Note that this result comes from a quantum simulator, which is a standard computer calculating what an ideal quantum computer would do. Simulations are only possible for small numbers of qubits (~30 qubits), but they are nevertheless a very useful tool when designing your first quantum circuits. To run on a real device you simply need to replace ```Aer.get_backend('aer_simulator')``` with the backend object of the device you want to use. "
+    "Note that this result comes from a quantum simulator, which is a standard computer calculating what an ideal quantum computer would do. Simulations are only possible for small numbers of qubits (~30 qubits), but they are nevertheless a very useful tool when designing your first quantum circuits. To run on a real device you simply need to replace `Aer.get_backend('aer_simulator')` with the backend object of the device you want to use. "
    ]
   },
   {


### PR DESCRIPTION
fixes issue #2

In this case, I made the install-win.sh and was tested in Git Bash.
The differences are as follow:
1st) in the windows .venv makes the "Scripts" directory rather than "bin".

2nd) I also made a new requirement-win.txt which uses the binary version of pyscf.

At last I also made the changes on the README.md file